### PR TITLE
Fix unexpected error while parsing empty DocString

### DIFF
--- a/src/ast/docString.ts
+++ b/src/ast/docString.ts
@@ -11,7 +11,7 @@ const debug = getDebugger("DocString");
 export class DocString extends UniqueObject {
   public static parse(obj: GherkinDocString, comments?: GherkinCommentHandler): DocString {
     debug("parse(obj: %o, comments: %d)", obj, comments?.comments?.length);
-    if (!obj || !obj.content) {
+    if (!obj || obj.content === undefined) {
       throw new TypeError("The given object is not a DocString!");
     }
     const docString = new DocString(obj.content, obj.delimiter, obj.mediaType);

--- a/tests/ast/docString.test.ts
+++ b/tests/ast/docString.test.ts
@@ -54,17 +54,20 @@ describe("DocString", () => {
       expect(() => DocString.parse(obj)).toThrow();
     });
 
-    test("should parse docString", () => {
-      // Given
-      const obj: GherkinDocString = {
-        content: "String",
-      } as GherkinDocString;
-      // When
-      const s: DocString = DocString.parse(obj);
-      // Then
-      expect(s).toBeDefined();
-      expect(s._id).toBeDefined();
-      expect(s.content).toEqual("String");
+    const validDocStrings = ["", "String"];
+    validDocStrings.forEach(content => {
+      test(`should parse next docString: '${content}'`, () => {
+        // Given
+        const obj: GherkinDocString = {
+          content: content,
+        } as GherkinDocString;
+        // When
+        const s: DocString = DocString.parse(obj);
+        // Then
+        expect(s).toBeDefined();
+        expect(s._id).toBeDefined();
+        expect(s.content).toEqual(content);
+      })
     });
   });
 });

--- a/tests/ast/docString.test.ts
+++ b/tests/ast/docString.test.ts
@@ -56,7 +56,7 @@ describe("DocString", () => {
 
     const validDocStrings = ["", "String"];
     validDocStrings.forEach(content => {
-      test(`should parse next docString: '${content}'`, () => {
+      test(`should parse valid docString: '${content}'`, () => {
         // Given
         const obj: GherkinDocString = {
           content: content,


### PR DESCRIPTION
Hi all,

There is an unexpected error happening when it parses the feature file with an empty DocString.
Empty DocString works fine with other languages/libraries and it is pretty handy when you pass data.

The fix is to stop using implicit cast but rather to check for undefined Content field.

All tests passed. @szikszail pls have a look.
<img width="797" alt="image" src="https://github.com/gherking/gherkin-ast/assets/19157402/877b3b25-6618-4019-bef0-d48a37066827">
